### PR TITLE
Allow "preview" and "send" to be sent as parameters to templateEngine

### DIFF
--- a/lib/email/EmailService.ts
+++ b/lib/email/EmailService.ts
@@ -39,6 +39,8 @@ export interface EmailServiceOptions extends NotificationServiceOptions {
     engine?: string;
     enabled: boolean;
     defaultTemplate?: string;
+    send?: boolean;
+    preview?: boolean;
   }
 }
 
@@ -88,7 +90,9 @@ export class Email extends NotificationService {
           options: {
             extension: this.options.template.engine || 'ejs'
           }
-        }
+        },
+        send: this.options.template.send,
+        preview: this.options.template.preview,
       });
     }
   }


### PR DESCRIPTION
In a dev enviroment (NODE_ENV='development') the  'email-templates' library (https://github.com/niftylettuce/email-templates) defaults the "send" property to false.
Doing so, we can't send any e-mails using that NODE_ENV.

This PR allows "send" and "preview" options to be sent to the templateEngine and therefore avoiding the issue above. 